### PR TITLE
Implement delete vectors

### DIFF
--- a/pinecone_sdk/src/pinecone/data.rs
+++ b/pinecone_sdk/src/pinecone/data.rs
@@ -9,7 +9,7 @@ use tonic::transport::Channel;
 use tonic::{Request, Status};
 
 pub use pb::{DescribeIndexStatsResponse, ListResponse, UpsertResponse, Vector};
-pub use prost_types::{value::Kind, Struct as MetadataFilter, Value};
+pub use prost_types::{value::Kind, Struct as Metadata, Value};
 
 /// Generated protobuf module for data plane.
 pub mod pb {
@@ -146,7 +146,7 @@ impl Index {
     /// The describe_index_stats operation returns statistics about the index.
     ///
     /// ### Arguments
-    /// * `filter: Option<MetadataFilter>` - An optional filter to specify which vectors to return statistics for. Note that the filter is only supported by pod indexes.
+    /// * `filter: Option<Metadata>` - An optional filter to specify which vectors to return statistics for. Note that the filter is only supported by pod indexes.
     ///
     /// ### Return
     /// * Returns a `Result<DescribeIndexStatsResponse, PineconeError>` object.
@@ -155,7 +155,7 @@ impl Index {
     /// ```no_run
     /// use std::collections::BTreeMap;
     /// use pinecone_sdk::pinecone::PineconeClient;
-    /// use pinecone_sdk::pinecone::data::{Value, Kind, MetadataFilter};
+    /// use pinecone_sdk::pinecone::data::{Value, Kind, Metadata};
     /// # use pinecone_sdk::utils::errors::PineconeError;
     ///
     /// # #[tokio::main]
@@ -167,13 +167,13 @@ impl Index {
     /// let mut fields = BTreeMap::new();
     /// fields.insert("field".to_string(), Value { kind: Some(Kind::StringValue("value".to_string())) });
     ///
-    /// let response = index.describe_index_stats(Some(MetadataFilter { fields })).await.unwrap();
+    /// let response = index.describe_index_stats(Some(Metadata { fields })).await.unwrap();
     /// # Ok(())
     /// # }
     /// ```
     pub async fn describe_index_stats(
         &mut self,
-        filter: Option<MetadataFilter>,
+        filter: Option<Metadata>,
     ) -> Result<DescribeIndexStatsResponse, PineconeError> {
         let request = pb::DescribeIndexStatsRequest { filter };
 
@@ -264,7 +264,7 @@ impl Index {
     /// The delete_by_filter operation deletes the vectors from a namespace that satisfy the filter.
     ///
     /// ### Arguments
-    /// * `filter: MetadataFilter` - The filter to specify which vectors to delete.
+    /// * `filter: Metadata` - The filter to specify which vectors to delete.
     /// * `namespace: Option<String>` - The namespace to delete vectors from.
     ///
     /// ### Return
@@ -274,7 +274,7 @@ impl Index {
     /// ```no_run
     /// use std::collections::BTreeMap;
     /// use pinecone_sdk::pinecone::PineconeClient;
-    /// use pinecone_sdk::pinecone::data::{MetadataFilter, Value, Kind};
+    /// use pinecone_sdk::pinecone::data::{Metadata, Value, Kind};
     /// # use pinecone_sdk::utils::errors::PineconeError;
     ///
     /// # #[tokio::main]
@@ -286,13 +286,13 @@ impl Index {
     /// let mut fields = BTreeMap::new();
     /// fields.insert("field".to_string(), Value { kind: Some(Kind::StringValue("value".to_string())) });
     ///
-    /// let response = index.delete_by_filter(MetadataFilter{ fields }, Some("namespace".to_string())).await.unwrap();
+    /// let response = index.delete_by_filter(Metadata { fields }, Some("namespace".to_string())).await.unwrap();
     /// # Ok(())
     /// # }
     /// ```
     pub async fn delete_by_filter(
         &mut self,
-        filter: MetadataFilter,
+        filter: Metadata,
         namespace: Option<String>,
     ) -> Result<(), PineconeError> {
         let request = pb::DeleteRequest {

--- a/pinecone_sdk/tests/integration_test.rs
+++ b/pinecone_sdk/tests/integration_test.rs
@@ -1,7 +1,7 @@
 use openapi::models::index_model::Metric as OpenApiMetric;
 use openapi::models::serverless_spec::Cloud as OpenApiCloud;
 use pinecone_sdk::pinecone::control::{Cloud, Metric, WaitPolicy};
-use pinecone_sdk::pinecone::data::{Kind, MetadataFilter, Value, Vector};
+use pinecone_sdk::pinecone::data::{Kind, Metadata, Value, Vector};
 use pinecone_sdk::pinecone::PineconeClient;
 use pinecone_sdk::utils::errors::PineconeError;
 use std::collections::BTreeMap;
@@ -523,7 +523,7 @@ async fn test_describe_index_stats_with_filter() -> Result<(), PineconeError> {
     );
 
     let describe_index_stats_response = index
-        .describe_index_stats(Some(MetadataFilter { fields: filter }))
+        .describe_index_stats(Some(Metadata { fields: filter }))
         .await
         .expect("Failed to describe index stats");
 
@@ -690,7 +690,7 @@ async fn test_delete_by_filter() -> Result<(), PineconeError> {
             id: "1".to_string(),
             values: vec![1.0; 12],
             sparse_values: None,
-            metadata: Some(MetadataFilter {
+            metadata: Some(Metadata {
                 fields: vec![(
                     "key".to_string(),
                     Value {
@@ -705,7 +705,7 @@ async fn test_delete_by_filter() -> Result<(), PineconeError> {
             id: "2".to_string(),
             values: vec![2.0; 12],
             sparse_values: None,
-            metadata: Some(MetadataFilter {
+            metadata: Some(Metadata {
                 fields: vec![(
                     "key".to_string(),
                     Value {
@@ -724,7 +724,7 @@ async fn test_delete_by_filter() -> Result<(), PineconeError> {
         .await
         .expect("Failed to upsert");
 
-    let filter = MetadataFilter {
+    let filter = Metadata {
         fields: vec![(
             "key".to_string(),
             Value {


### PR DESCRIPTION
## Problem

There is no implemented way of deleting vectors from an index.

## Solution

I implemented three separate functions for each of the three methods of deleting vectors: `delete_by_id`, `delete_by_filter`, and `delete_all`. Each one of these constructs the appropriate `DeleteRequest` struct and passes it to a `delete` helper function that calls the tonic function.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

New and old test cases should pass.