### PR TITLE
Create Namespace struct

### DIFF
--- a/pinecone_sdk/src/pinecone/data.rs
+++ b/pinecone_sdk/src/pinecone/data.rs
@@ -86,23 +86,23 @@ impl Index {
     ///
     /// let mut index = pinecone.index("index-host").await.unwrap();
     ///
-    /// let vectors = vec![Vector {
+    /// let vectors = [Vector {
     ///     id: "vector-id".to_string(),
     ///     values: vec![1.0, 2.0, 3.0, 4.0],
     ///     sparse_values: None,
     ///     metadata: None,
     /// }];
-    /// let response = index.upsert(vectors, &"namespace".into()).await.unwrap();
+    /// let response = index.upsert(&vectors, &"namespace".into()).await.unwrap();
     /// # Ok(())
     /// # }
     /// ```
     pub async fn upsert(
         &mut self,
-        vectors: Vec<Vector>,
+        vectors: &[Vector],
         namespace: &Namespace,
     ) -> Result<UpsertResponse, PineconeError> {
         let request = pb::UpsertRequest {
-            vectors,
+            vectors: vectors.to_vec(),
             namespace: namespace.name.clone(),
         };
 
@@ -287,18 +287,18 @@ impl Index {
     ///
     /// let mut index = pinecone.index("index-host").await.unwrap();
     ///
-    /// let ids = vec!["vector-id".to_string()];
-    /// let response = index.delete_by_id(ids, &"namespace".into()).await.unwrap();
+    /// let ids = ["vector-id".to_string()];
+    /// let response = index.delete_by_id(&ids, &"namespace".into()).await.unwrap();
     /// # Ok(())
     /// # }
     /// ```
     pub async fn delete_by_id(
         &mut self,
-        ids: Vec<String>,
+        ids: &[String],
         namespace: &Namespace,
     ) -> Result<(), PineconeError> {
         let request = pb::DeleteRequest {
-            ids,
+            ids: ids.to_vec(),
             delete_all: false,
             namespace: namespace.name.clone(),
             filter: None,


### PR DESCRIPTION
## Problem

Currently the `namespace` parameter for data plane functions is of type `Option<String>`, but this is slightly misleading as it seems like the namespace isn't necessary for these operations even though it is -- we are just using `None` as a way to specify the default namespace.

## Solution

I implemented a `Namespace` struct which has a `name` parameter that contains the name of the namespace. I then updated all instances of the `namespace` parameter to take in a type `&Namespace`, as well as some code for `Namespace` so that it is easier to use.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Old test cases should pass.