### PR TITLE
Refactor `PineconeError`: use `thiserror`/`anyhow`, ensure we support `Send + Sync`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pinecone-sdk"
 version = "0.1.1"
 dependencies = [
+ "anyhow",
  "httpmock",
  "once_cell",
  "prost",
@@ -1489,6 +1490,7 @@ dependencies = [
  "serial_test",
  "snafu",
  "temp-env",
+ "thiserror",
  "tokio",
  "tonic",
  "tonic-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ serde = { version = "^1.0", features = ["derive"] }
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
 reqwest = { version = "^0.12", features = ["json", "multipart"] }
+thiserror = "1.0.63"
+anyhow = "1.0.86"
 
 [dev-dependencies]
 temp-env = "0.3"

--- a/src/pinecone/data.rs
+++ b/src/pinecone/data.rs
@@ -634,20 +634,14 @@ impl PineconeClient {
 
         // connect to server
         let endpoint = Channel::from_shared(host)
-            .map_err(|e| PineconeError::ConnectionError {
-                source: Box::new(e),
-            })?
+            .map_err(|e| PineconeError::ConnectionError { source: e.into() })?
             .tls_config(tls_config)
-            .map_err(|e| PineconeError::ConnectionError {
-                source: Box::new(e),
-            })?;
+            .map_err(|e| PineconeError::ConnectionError { source: e.into() })?;
 
         let channel = endpoint
             .connect()
             .await
-            .map_err(|e| PineconeError::ConnectionError {
-                source: Box::new(e),
-            })?;
+            .map_err(|e| PineconeError::ConnectionError { source: e.into() })?;
 
         // add api key in metadata through interceptor
         let token: TonicMetadataVal<_> = self.api_key.parse().unwrap();

--- a/src/pinecone/mod.rs
+++ b/src/pinecone/mod.rs
@@ -124,7 +124,7 @@ impl PineconeClientConfig {
         let client = reqwest::Client::builder()
             .default_headers(headers)
             .build()
-            .map_err(|e| PineconeError::ReqwestError { source: e })?;
+            .map_err(|e| PineconeError::ReqwestError { source: e.into() })?;
 
         let openapi_config = Configuration {
             base_path: controller_host.to_string(),


### PR DESCRIPTION
## Problem
Currently, `PineconeError` contains a lot of boilerplate for implementing `std::error::Error`. @haruska suggested we could maybe simplify some of the boilerplate using the `thiserror` and `anyhow` crates.

Additionally, there was an enhancement filed (https://github.com/pinecone-io/pinecone-rust-client/issues/54) to implement `Send` + `Sync` for `PineconeError` as currently we're unable to use `PineconeError` in a multithreaded context.

## Solution
Refactor PineconeError to use thiserror and anyhow to reduce some of our boilerplate for the custom error enum, make sure we can safely use PineconeError with Send and Sync, add unit test for this

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X]  New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
New unit test added to verify that `PineoneError` has properly implemented the `Send` and `Sync` traits.

`cargo test` -> validate CI passes as expected


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208161607942725
  - https://app.asana.com/0/0/1208161607942720