### PR TITLE
Bump version `v0.1.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,7 +1475,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinecone-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "httpmock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinecone-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Pinecone Rust SDK"
 repository = "https://github.com/pinecone-io/pinecone-rust-client"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Before you can use the Pinecone SDK, you must sign up for an account and find yo
 
 ## Installation
 
-Run `cargo add pinecone-sdk` to add the crate as a dependency, or add the line `pinecone-sdk = "0.1.1"` to your Cargo.toml file under `[dependencies]`. More on the crate can be found [here](https://crates.io/crates/pinecone-sdk).
+Run `cargo add pinecone-sdk` to add the crate as a dependency, or add the line `pinecone-sdk = "0.1.2"` to your Cargo.toml file under `[dependencies]`. More on the crate can be found [here](https://crates.io/crates/pinecone-sdk).
 
 ## Usage
 


### PR DESCRIPTION
## Problem
We'd like to push a new version of the SDK and need to bump the version in the `Cargo.toml` file before running `cargo publish`. 

For now this is all done manually.

## Solution

- Update `Cargo.lock` and `Cargo.toml` to `v0.1.2`.
- Update README example.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
N/A
